### PR TITLE
Remove trimming optimization from .bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v0.4.4
+* Remove deletion of delay messages after queues messages are sent from `.bulk`
+
 ## v0.4.3
 * Change gemspec to support older redis versions again
 

--- a/lib/redstream/producer.rb
+++ b/lib/redstream/producer.rb
@@ -92,10 +92,10 @@ module Redstream
     # @param records [#to_a] The object/objects that will be updated deleted
 
     def bulk_queue(records)
-      records.each_with_index.each_slice(250) do |slice|
+      records.each_slice(250) do |slice|
         Redstream.connection_pool.with do |redis|
           redis.pipelined do |pipeline|
-            slice.each do |object, index|
+            slice.each do |object|
               pipeline.xadd(Redstream.stream_key_name(stream_name(object)), { payload: JSON.dump(object.redstream_payload) })
             end
           end

--- a/lib/redstream/version.rb
+++ b/lib/redstream/version.rb
@@ -1,3 +1,3 @@
 module Redstream
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end

--- a/redstream.gemspec
+++ b/redstream.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "activerecord"

--- a/spec/redstream/producer_spec.rb
+++ b/spec/redstream/producer_spec.rb
@@ -78,19 +78,6 @@ RSpec.describe Redstream::Producer do
         { "payload" => JSON.dump(products[1].redstream_payload) }
       ])
     end
-
-    it "deletes the delay messages after the queue messages have been sent" do
-      products = create_list(:product, 2)
-      producer = Redstream::Producer.new
-
-      other_delay_message_id = producer.delay(create(:product))
-
-      producer.bulk(products) do
-        expect(redis.xlen(Redstream.stream_key_name("products.delay"))).to eq(3)
-      end
-
-      expect(redis.xrange(Redstream.stream_key_name("products.delay"), "-", "+").map(&:first)).to eq([other_delay_message_id])
-    end
   end
 
   describe "#bulk_queue" do
@@ -107,18 +94,6 @@ RSpec.describe Redstream::Producer do
         { "payload" => JSON.dump(products[0].redstream_payload) },
         { "payload" => JSON.dump(products[1].redstream_payload) }
       ])
-    end
-
-    it "deletes the delay messages after the queue messages have been sent" do
-      products = create_list(:product, 2)
-      producer = Redstream::Producer.new
-
-      delay_message_ids = producer.bulk_delay(products)
-      other_delay_message_id = producer.delay(create(:product))
-
-      producer.bulk_queue(products, delay_message_ids: delay_message_ids)
-
-      expect(redis.xrange(Redstream.stream_key_name("products.delay"), "-", "+").map(&:first)).to eq([other_delay_message_id])
     end
   end
 


### PR DESCRIPTION
I realized that the optimization in `Producer.bulk`  to delete delay messages after queue message have been sent is too dangerous. When code is wrapped in a transaction and records get deleted, then there is a potential risk of running out of sync. Thefore, the optimization is completely removed from `Producer.bulk`.